### PR TITLE
Shiyuan/gettreenode fix

### DIFF
--- a/src/service-implementations/lf-repo-tree-node-service.spec.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.spec.ts
@@ -1,9 +1,23 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-import { LfRepoTreeNodeService, nodeAttrName_elecDocumentSize, nodeAttrName_extension, nodeAttrName_templateName, nodeAttrName_creationTime } from './lf-repo-tree-node-service'
+import {
+  LfRepoTreeNodeService,
+  nodeAttrName_elecDocumentSize,
+  nodeAttrName_extension,
+  nodeAttrName_templateName,
+  nodeAttrName_creationTime,
+} from './lf-repo-tree-node-service';
 import { LfRepoTreeNode } from '../helper-types/lf-repo-browser-types';
-import { Entry, PostEntryChildrenRequest, EntryType, ODataValueContextOfIListOfEntry, Document, Shortcut, Folder } from '@laserfiche/lf-repository-api-client';
+import {
+  Entry,
+  PostEntryChildrenRequest,
+  EntryType,
+  ODataValueContextOfIListOfEntry,
+  Document,
+  Shortcut,
+  Folder,
+} from '@laserfiche/lf-repository-api-client';
 import { RepositoryApiClientMockBuilder } from './repository-api-client-mock-builder';
 import { FindEntryResult } from '@laserfiche/lf-repository-api-client';
 import * as RepoClientUtils from '../utils/repo-client-utils';
@@ -34,13 +48,13 @@ function createFindEntryResult(data): FindEntryResult {
 const dummyRootEntry: Folder = createFolder({
   id: 1,
   name: 'DummyRoot',
-  entryType: EntryType.Folder
+  entryType: EntryType.Folder,
 });
 
 const dummyFolderEntry: Folder = createFolder({
   id: 10,
   name: 'DummyFolder',
-  entryType: EntryType.Folder
+  entryType: EntryType.Folder,
 });
 
 const dummyDocumentEntryDocument: Document = createDocument({
@@ -64,7 +78,7 @@ const dummyShortcutDocumentShortcut: Shortcut = createShortcut({
   templateName: 'hi',
   targetId: 20000,
   extension: 'docx',
-  targetType: EntryType.Document
+  targetType: EntryType.Document,
 });
 
 const dummyShortcutFolderShortcut: Shortcut = createShortcut({
@@ -72,14 +86,20 @@ const dummyShortcutFolderShortcut: Shortcut = createShortcut({
   name: 'dummyShortcutFolder',
   entryType: EntryType.Shortcut,
   targetId: 20000,
-  targetType: EntryType.Folder
+  targetType: EntryType.Folder,
 });
 
 let service: LfRepoTreeNodeService;
 
 const mockChildren: Entry[] = [
   createFolder({ id: 1, name: 'root', fullPath: '\\', entryType: EntryType.Folder, parentId: 0 }),
-  createDocument({ id: 11, name: 'DocInRoot', fullPath: '\\DocInRoot', entryType: EntryType.Document, templateName: 'test' }),
+  createDocument({
+    id: 11,
+    name: 'DocInRoot',
+    fullPath: '\\DocInRoot',
+    entryType: EntryType.Document,
+    templateName: 'test',
+  }),
   createFolder({ id: 12, name: 'FolderInRoot', fullPath: '\\FolderInRoot', entryType: EntryType.Folder }),
   createFolder({ id: 52, name: 'FolderInRoot1', fullPath: '\\FolderInRoot1', entryType: EntryType.Folder }),
   createFolder({ id: 53, name: 'FolderInRoot2', fullPath: '\\FolderInRoot2', entryType: EntryType.Folder }),
@@ -91,81 +111,155 @@ const mockChildren: Entry[] = [
   createFolder({ id: 59, name: 'FolderInRoot8', fullPath: '\\FolderInRoot8', entryType: EntryType.Folder }),
   createFolder({ id: 60, name: 'FolderInRoot9', fullPath: '\\FolderInRoot9', entryType: EntryType.Folder }),
   createFolder({ id: 61, name: 'FolderInRoot10', fullPath: '\\FolderInRoot10', entryType: EntryType.Folder }),
-  createFolder({ id: 62, name: 'FolderInAFolder', fullPath: '\\FolderInRoot\\FolderInAFolder', entryType: EntryType.Folder }),
-  createDocument({ id: 13, name: 'DocInFolderInRoot', fullPath: '\\FolderInRoot\\DocInFolderInRoot', entryType: EntryType.Document }),
-  createDocument({ id: 20, name: 'RsInFolderInRoot', fullPath: '\\FolderInRoot\\RsInFolderInRoot', entryType: EntryType.Document }),
-  createDocument({ id: 21, name: 'RsInFolderInRoot1', fullPath: '\\FolderInRoot\\RsInFolderInRoot1', entryType: EntryType.Document }),
-  createDocument({ id: 22, name: 'RsInFolderInRoot2', fullPath: '\\FolderInRoot\\RsInFolderInRoot2', entryType: EntryType.Document }),
-  createDocument({ id: 23, name: 'RsInFolderInRoot3', fullPath: '\\FolderInRoot\\RsInFolderInRoot3', entryType: EntryType.Document }),
-  createDocument({ id: 24, name: 'RsInFolderInRoot4', fullPath: '\\FolderInRoot\\RsInFolderInRoot4', entryType: EntryType.Document }),
-  createDocument({ id: 25, name: 'RsInFolderInRoot5', fullPath: '\\FolderInRoot\\RsInFolderInRoot5', entryType: EntryType.Document }),
-  createDocument({ id: 26, name: 'RsInFolderInRoot6', fullPath: '\\FolderInRoot\\RsInFolderInRoot6', entryType: EntryType.Document }),
-  createDocument({ id: 27, name: 'RsInFolderInRoot7', fullPath: '\\FolderInRoot\\RsInFolderInRoot7', entryType: EntryType.Document }),
-  createDocument({ id: 28, name: 'RsInFolderInRoot8', fullPath: '\\FolderInRoot\\RsInFolderInRoot8', entryType: EntryType.Document }),
-  createDocument({ id: 29, name: 'RsInFolderInRoot9', fullPath: '\\FolderInRoot\\RsInFolderInRoot9', entryType: EntryType.Document }),
-]
+  createFolder({
+    id: 62,
+    name: 'FolderInAFolder',
+    fullPath: '\\FolderInRoot\\FolderInAFolder',
+    entryType: EntryType.Folder,
+  }),
+  createDocument({
+    id: 13,
+    name: 'DocInFolderInRoot',
+    fullPath: '\\FolderInRoot\\DocInFolderInRoot',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 20,
+    name: 'RsInFolderInRoot',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 21,
+    name: 'RsInFolderInRoot1',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot1',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 22,
+    name: 'RsInFolderInRoot2',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot2',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 23,
+    name: 'RsInFolderInRoot3',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot3',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 24,
+    name: 'RsInFolderInRoot4',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot4',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 25,
+    name: 'RsInFolderInRoot5',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot5',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 26,
+    name: 'RsInFolderInRoot6',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot6',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 27,
+    name: 'RsInFolderInRoot7',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot7',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 28,
+    name: 'RsInFolderInRoot8',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot8',
+    entryType: EntryType.Document,
+  }),
+  createDocument({
+    id: 29,
+    name: 'RsInFolderInRoot9',
+    fullPath: '\\FolderInRoot\\RsInFolderInRoot9',
+    entryType: EntryType.Document,
+  }),
+];
 
 const mockRepoClient = new RepositoryApiClientMockBuilder()
-  .withGetCurrentRepoId(async () => { return 'r-23456789' })
-  .withGetCurrentRepoName(async () => { return 'Test Name' })
+  .withGetCurrentRepoId(async () => {
+    return 'r-23456789';
+  })
+  .withGetCurrentRepoName(async () => {
+    return 'Test Name';
+  })
   .withEntriesClient({
-    getEntryListing: jest.fn((args: {
-      repoId: string;
-      entryId: number;
-      groupByEntryType?: boolean;
-      fields?: string[];
-      formatFields?: boolean;
-      prefer?: string;
-      culture?: string;
-      select?: string;
-      orderby?: string;
-      top?: number;
-      skip?: number;
-      count?: boolean;
-    }) => {
+    getEntryListing: jest.fn(
+      (args: {
+        repoId: string;
+        entryId: number;
+        groupByEntryType?: boolean;
+        fields?: string[];
+        formatFields?: boolean;
+        prefer?: string;
+        culture?: string;
+        select?: string;
+        orderby?: string;
+        top?: number;
+        skip?: number;
+        count?: boolean;
+      }) => {
+        return Promise.resolve(
+          createResultEntryListing({
+            value: mockChildren.slice(0, 20),
+            odataNextLink: 'a test link returned by getEntryListing',
+          })
+        );
+      }
+    ),
+    getEntryListingNextLink: jest.fn((args: { nextLink: string; maxPageSize?: number }) => {
       return Promise.resolve(
-        createResultEntryListing({ value: mockChildren.slice(0, 20), odataNextLink: 'a test link returned by getEntryListing' }))
+        createResultEntryListing({
+          value: mockChildren.slice(0, 20),
+          odataNextLink: 'a test link returned by getEntryListingNextLink',
+        })
+      );
     }),
-    getEntryListingNextLink: jest.fn((args: {
-      nextLink: string;
-      maxPageSize?: number
-    }) => {
-      return Promise.resolve(
-        createResultEntryListing({ value: mockChildren.slice(0, 20), odataNextLink: 'a test link returned by getEntryListingNextLink' })
-      )
-    }),
-    getEntry: jest.fn((args: { repoId, entryId }) => {
+    getEntry: jest.fn((args: { repoId: string; entryId: number }) => {
       let matchedChild: Entry;
-      mockChildren.forEach(child => {
+      for (const child of mockChildren) {
         if (child.id === args.entryId) {
           matchedChild = child;
           return Promise.resolve(matchedChild);
         }
-      })
+      }
       return Promise.resolve(mockChildren[0]);
     }),
-    createOrCopyEntry: jest.fn((args: { repoId: string, entryId: number, request: PostEntryChildrenRequest }) => {
-      const newFolder: Entry = new Folder({ id: 100, name: args.request.name, entryType: EntryType.Folder, parentId: 0 });
+    createOrCopyEntry: jest.fn((args: { repoId: string; entryId: number; request: PostEntryChildrenRequest }) => {
+      const newFolder: Entry = new Folder({
+        id: 100,
+        name: args.request.name,
+        entryType: EntryType.Folder,
+        parentId: 0,
+      });
       mockChildren.push(newFolder);
       return Promise.resolve(newFolder);
     }),
-    getEntryByPath: jest.fn((args: { repoId: string, fullPath: string, fallbackToClosestAncestor?: boolean }) => {
-      const entry: Entry | undefined = mockChildren.find(child => child.fullPath === args.fullPath);
+    getEntryByPath: jest.fn((args: { repoId: string; fullPath: string; fallbackToClosestAncestor?: boolean }) => {
+      const entry: Entry | undefined = mockChildren.find((child) => child.fullPath === args.fullPath);
       if (entry) {
-        return Promise.resolve(createFindEntryResult({
-          entry: entry
-      }));
+        return Promise.resolve(
+          createFindEntryResult({
+            entry: entry,
+          })
+        );
+      } else {
+        return Promise.reject(new Error('Entry not Found 404'));
       }
-      else {
-        return Promise.reject();
-      }
-
     }),
   })
   .build();
 
 describe('LfRepoTreeNodeService', () => {
-
   beforeEach(() => {
     service = new LfRepoTreeNodeService(mockRepoClient);
   });
@@ -183,12 +277,15 @@ describe('LfRepoTreeNodeService', () => {
       isContainer: true,
       isLeaf: false,
       attributes: new Map<string, PropertyValue>(),
-      entryType: EntryType.Folder
+      entryType: EntryType.Folder,
     };
-    
+
     // @ts-ignore
-    const createdNode = service.createNonRootLfRepoTreeNode(dummyFolderEntry, { name: 'Test Name', path: '\\' } as LfRepoTreeNode);
-    
+    const createdNode = service.createNonRootLfRepoTreeNode(dummyFolderEntry, {
+      name: 'Test Name',
+      path: '\\',
+    } as LfRepoTreeNode);
+
     expect(createdNode).toEqual(expectedNode);
   });
 
@@ -198,20 +295,23 @@ describe('LfRepoTreeNodeService', () => {
       path: '\\dummyShortcutFolder',
       id: '14',
       icon: [
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#folder-20",
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay",
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#folder-20',
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay',
       ],
       isContainer: true,
       isLeaf: false,
       attributes: new Map<string, PropertyValue>(),
       entryType: EntryType.Shortcut,
       targetId: 20000,
-      targetType: EntryType.Folder
+      targetType: EntryType.Folder,
     };
 
     // @ts-ignore
-    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutFolderShortcut, { name: 'Test Name', path: '\\' } as LfRepoTreeNode);
-    
+    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutFolderShortcut, {
+      name: 'Test Name',
+      path: '\\',
+    } as LfRepoTreeNode);
+
     expect(createdNode).toEqual(expectedNode);
   });
 
@@ -221,23 +321,26 @@ describe('LfRepoTreeNodeService', () => {
       path: '\\dummyShortcutDocument',
       id: '13',
       icon: [
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#edoc-wordprocessing-20",
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay",
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#edoc-wordprocessing-20',
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay',
       ],
       isContainer: false,
       isLeaf: true,
       attributes: new Map<string, PropertyValue>(),
       entryType: EntryType.Shortcut,
       targetId: 20000,
-      targetType: EntryType.Document
+      targetType: EntryType.Document,
     };
-    expectedNode.attributes!.set(nodeAttrName_extension, {value:'docx', displayValue:'docx'});
-    expectedNode.attributes!.set(nodeAttrName_templateName, {value:'hi', displayValue: 'hi'});
+    expectedNode.attributes!.set(nodeAttrName_extension, { value: 'docx', displayValue: 'docx' });
+    expectedNode.attributes!.set(nodeAttrName_templateName, { value: 'hi', displayValue: 'hi' });
     service.columnIds = [nodeAttrName_extension, nodeAttrName_templateName];
-    
+
     // @ts-ignore
-    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut, { name: 'Test Name', path: '\\' } as LfRepoTreeNode);
-    
+    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut, {
+      name: 'Test Name',
+      path: '\\',
+    } as LfRepoTreeNode);
+
     expect(createdNode).toEqual(expectedNode);
   });
 
@@ -247,19 +350,22 @@ describe('LfRepoTreeNodeService', () => {
       path: '\\dummyShortcutDocument',
       id: '13',
       icon: [
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#edoc-wordprocessing-20",
-        "https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay",
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#edoc-wordprocessing-20',
+        'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@5/resources/icons/document-icons.svg#shortcut-overlay',
       ],
       isContainer: false,
       isLeaf: true,
       attributes: new Map<string, PropertyValue>(),
       entryType: EntryType.Shortcut,
       targetId: 20000,
-      targetType: EntryType.Document
+      targetType: EntryType.Document,
     };
 
     // @ts-ignore
-    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut, { name: 'Test Name', path: '\\' } as LfRepoTreeNode);
+    const createdNode = service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut, {
+      name: 'Test Name',
+      path: '\\',
+    } as LfRepoTreeNode);
     expect(createdNode).toEqual(expectedNode);
   });
 
@@ -276,26 +382,40 @@ describe('LfRepoTreeNodeService', () => {
       entryType: EntryType.Document,
     };
     expectedNode.attributes = new Map<string, PropertyValue>();
-    expectedNode.attributes.set(nodeAttrName_elecDocumentSize, {value:20000, displayValue: '19.53 KB'});
-    expectedNode.attributes.set(nodeAttrName_extension, {value:'docx', displayValue: 'docx'});
-    expectedNode.attributes.set(nodeAttrName_templateName, {value: 'hi', displayValue: 'hi'});
-    expectedNode.attributes.set(nodeAttrName_creationTime, {value: '2000-05-11T00:00:00', displayValue: '5/11/2000, 12:00:00 AM'})
-    service.columnIds = [nodeAttrName_elecDocumentSize,nodeAttrName_extension,nodeAttrName_templateName, nodeAttrName_creationTime];
+    expectedNode.attributes.set(nodeAttrName_elecDocumentSize, { value: 20000, displayValue: '19.53 KB' });
+    expectedNode.attributes.set(nodeAttrName_extension, { value: 'docx', displayValue: 'docx' });
+    expectedNode.attributes.set(nodeAttrName_templateName, { value: 'hi', displayValue: 'hi' });
+    expectedNode.attributes.set(nodeAttrName_creationTime, {
+      value: '2000-05-11T00:00:00',
+      displayValue: '5/11/2000, 12:00:00 AM',
+    });
+    service.columnIds = [
+      nodeAttrName_elecDocumentSize,
+      nodeAttrName_extension,
+      nodeAttrName_templateName,
+      nodeAttrName_creationTime,
+    ];
 
     // @ts-ignore
-    const createdNode = service.createNonRootLfRepoTreeNode(dummyDocumentEntryDocument, { name: 'Test Name', path: '\\' } as LfRepoTreeNode);
+    const createdNode = service.createNonRootLfRepoTreeNode(dummyDocumentEntryDocument, {
+      name: 'Test Name',
+      path: '\\',
+    } as LfRepoTreeNode);
     expect(createdNode).toEqual(expectedNode);
-
   });
 
   it('should throw exception if entryType not set', () => {
-    // @ts-ignore
-    expect(() => service.createNonRootLfRepoTreeNode(dummyInvalidEntry, { name: 'Test Name', path: '\\' } as LfRepoTreeNode)).toThrow(`Entry type is undefined for entry: ${dummyInvalidEntry.id}`);
+    expect(() =>
+      // @ts-ignore
+      service.createNonRootLfRepoTreeNode(dummyInvalidEntry, { name: 'Test Name', path: '\\' } as LfRepoTreeNode)
+    ).toThrow(`Entry type is undefined for entry: ${dummyInvalidEntry.id}`);
   });
 
   it('should throw exception if create a non-root node if parent is not provided', () => {
     // @ts-ignore
-    expect(() => service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut)).toThrow(`Unable to determine path of entry: ${dummyShortcutDocumentShortcut.id}`);
+    expect(() => service.createNonRootLfRepoTreeNode(dummyShortcutDocumentShortcut)).toThrow(
+      `Unable to determine path of entry: ${dummyShortcutDocumentShortcut.id}`
+    );
   });
 
   it('can choose to view only folders, not documents or record series', async () => {
@@ -305,9 +425,7 @@ describe('LfRepoTreeNodeService', () => {
     const childrenNodes = await service.getFolderChildrenAsync({ id: '1', path: '//' } as LfRepoTreeNode);
 
     // Assert
-    const expectedIds = ['1', '12', '52', '53', '54',
-      '55', '56', '57', '58', '59',
-      '60', '61', '62'];
+    const expectedIds = ['1', '12', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62'];
     const actualIds = childrenNodes.page.map((entry) => entry.id).sort();
     expect(actualIds).toEqual(expectedIds);
     expect(childrenNodes.page.length).toEqual(13);
@@ -316,7 +434,7 @@ describe('LfRepoTreeNodeService', () => {
   it('getRootNodesAsync should call API getEntryAsync and coerce parentId = 0 into parentId = undefined', async () => {
     // Act
     const rootNodes = await service.getRootTreeNodeAsync();
-    const expectedNode : LfRepoTreeNode = {
+    const expectedNode: LfRepoTreeNode = {
       name: 'Test Name',
       path: '\\',
       id: '1',
@@ -324,7 +442,7 @@ describe('LfRepoTreeNodeService', () => {
       isContainer: true,
       isLeaf: false,
       entryType: EntryType.Folder,
-      attributes: new Map<string, PropertyValue>()
+      attributes: new Map<string, PropertyValue>(),
     };
 
     // Assert
@@ -341,10 +459,10 @@ describe('LfRepoTreeNodeService', () => {
 
     // Assert
     expect(childrenNodes.page.length).toEqual(20);
-    expect(childrenNodes.nextPage).toEqual("a test link returned by getEntryListing");
+    expect(childrenNodes.nextPage).toEqual('a test link returned by getEntryListing');
     childrenNodes.page.forEach((childNode, i) => {
       expect(childNode.name).toEqual(mockChildren[i].name);
-    })
+    });
   });
 
   it('getFolderChildrenAsync with nextPage should call API getEntryListingNextLink ', async () => {
@@ -359,7 +477,7 @@ describe('LfRepoTreeNodeService', () => {
     expect(childrenNodes.nextPage).toEqual('a test link returned by getEntryListingNextLink');
     childrenNodes.page.forEach((childNode, i) => {
       expect(childNode.name).toEqual(mockChildren[i].name);
-    })
+    });
   });
 
   it('getFolderChildrenAsync will call getFolderChildrenDefaultParameters with columnIds', async () => {
@@ -393,7 +511,7 @@ describe('LfRepoTreeNodeService', () => {
       isContainer: true,
       isLeaf: false,
       entryType: EntryType.Folder,
-      attributes: new Map<string, PropertyValue>()
+      attributes: new Map<string, PropertyValue>(),
     };
 
     // Act
@@ -413,11 +531,15 @@ describe('LfRepoTreeNodeService', () => {
       isContainer: true,
       isLeaf: false,
       entryType: EntryType.Folder,
-      attributes: new Map<string, PropertyValue>()
+      attributes: new Map<string, PropertyValue>(),
     };
 
     // Act
-    const parent = await service.getParentTreeNodeAsync({ id: '2', path: '\\FolderInRoot\\test1', name: 'test1' } as LfRepoTreeNode);
+    const parent = await service.getParentTreeNodeAsync({
+      id: '2',
+      path: '\\FolderInRoot\\test1',
+      name: 'test1',
+    } as LfRepoTreeNode);
 
     // Assert
     expect(parent).toEqual(expectedNode);
@@ -433,16 +555,68 @@ describe('LfRepoTreeNodeService', () => {
       isContainer: true,
       isLeaf: false,
       entryType: EntryType.Folder,
-      attributes: new Map<string, PropertyValue>()
+      attributes: new Map<string, PropertyValue>(),
     };
 
     // Act
-    const parent = await service.getParentTreeNodeAsync({ id: '2', path: '\\FolderInRoot\\FolderInAFolder\\test1', name: 'test1' } as LfRepoTreeNode);
+    const parent = await service.getParentTreeNodeAsync({
+      id: '2',
+      path: '\\FolderInRoot\\FolderInAFolder\\test1',
+      name: 'test1',
+    } as LfRepoTreeNode);
 
     // Assert
     expect(parent).toEqual(expectedNode);
   });
 
+  it('getLfEntryId should return Entry Id when the identifier is a Laserfiche Entry Id', () => {
+    // Arrange
+    const identifier = '12345';
+    // Act
+    // @ts-ignore
+    const actualEntryId = service.getLfEntryId(identifier);
+    // Assert
+    expect(actualEntryId).toEqual(12345);
+  });
 
+  it('getLfEntryId should return undefined if the identifier is not Laserfiche Entry Id', () => {
+    // Arrange
+    let identifier = '\\12345';
+    // Act and Assert
+    // @ts-ignore
+    expect(service.getLfEntryId(identifier)).toBeUndefined();
+    // Arrange
+    identifier = 'path\\to\\node';
+    // Act and Assert
+    // @ts-ignore
+    expect(service.getLfEntryId(identifier)).toBeUndefined();
+  });
 
-})
+  it('getTreeNodeByIdentifierAsync should return a tree node when identifier is Lf Entry Id', async () => {
+    // Arrange
+    const testTreeNode: Entry = mockChildren[1];
+    const testIdentifier = testTreeNode.id!.toString();
+
+    // Act
+    const actualTreeNode: LfTreeNode | undefined = await service.getTreeNodeByIdentifierAsync(testIdentifier);
+    // Assert
+    expect(actualTreeNode).toBeDefined();
+    expect(actualTreeNode?.id).toEqual(testIdentifier);
+  });
+
+  it('getTreeNodeByIdentifierAsync should return a tree node when identifier is a path to node', async () => {
+    // Arrange
+    const testTreeNode: Entry = mockChildren[1];
+    const testIdentifier = testTreeNode.fullPath!;
+    // Act
+    const actualTreeNode: LfTreeNode | undefined = await service.getTreeNodeByIdentifierAsync(testIdentifier);
+    // Assert
+    expect(actualTreeNode).toBeDefined();
+    expect(actualTreeNode?.path).toEqual(testIdentifier);
+  });
+
+  it('getTreeNodeByIdentifierAsync should throw if TreeNode not found', async () => {
+    const identifier: string = 'tree-node-not-exist';
+    await expect(service.getTreeNodeByIdentifierAsync(identifier)).rejects.toThrow();
+  });
+});

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -23,12 +23,18 @@ import {
   LfTreeNodeService,
   PropertyValue,
 } from '@laserfiche/types-lf-ui-components';
+import path, { parse } from 'path';
 
 export const nodeAttrName_extension = 'extension';
 export const nodeAttrName_elecDocumentSize = 'elecDocumentSize';
 export const nodeAttrName_templateName = 'templateName';
 export const nodeAttrName_creationTime = 'creationTime';
 const rootFolderId: number = 1;
+
+interface LfTreeNodeId {
+  entryId?: number;
+  pathToNode?: string;
+}
 
 export class LfRepoTreeNodeService implements LfTreeNodeService {
   /**
@@ -257,7 +263,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
 
   /**
    * Returns the LfRepoTreeNode represented by the path
-   * @param nodePath Unique identifier for the node, in this implementation the path of the node
+   * @param identifier Unique identifier for the node. Can be either the full path (starting with '\') or the Laserfiche Repository Entry Id.
    * @returns The LfRepoTreeNode at the specified path, or throws if it does not exist
    * @example
    * ``` ts
@@ -277,20 +283,48 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
    * const nestedUnderShortcut = getTreeNodeByIdentifierAsync('\FolderInRoot2\ShortcutToFolderInRoot1\DocInFolderInRoot') // returns definition for DocInFolderInRoot, with path to shortcut rather than path to true location
    * ```
    */
-  async getTreeNodeByIdentifierAsync(pathToNode: string): Promise<LfTreeNode | undefined> {
+  async getTreeNodeByIdentifierAsync(identifier: string): Promise<LfTreeNode | undefined> {
     const repoId: string = await this.repoClient.getCurrentRepoId();
-    let treeNode: LfTreeNode;
-      const findEntryResult: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
-        fullPath: pathToNode,
+    const entryId: number | undefined = this.getLfEntryId(identifier);
+    let entryFound: Entry;
+    if (entryId) {
+      entryFound = await this.repoClient.entriesClient.getEntry({
+        entryId: entryId,
         repoId: repoId,
       });
-      if (findEntryResult.entry) {
-        treeNode = await this.createTreeNodeAsync(findEntryResult.entry);
-        treeNode.path = pathToNode; // overwrite the path. pathToNode is different from the returned path when the entry is a folder under a shortcut.
-      } else {
-        throw new Error(`Unable to get entry with identifier: ${pathToNode}`);
-      }
+    } else {
+      entryFound = await this.getEntryByPath(identifier, repoId);
+    }
+    const treeNode: LfTreeNode = await this.createTreeNodeAsync(entryFound);
     return treeNode;
+  }
+
+  /** throws if entry not found */
+  private async getEntryByPath(pathToNode: string, repoId: string) : Promise<Entry>{
+    let entryFound: Entry;
+    const findEntryResult: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
+      fullPath: pathToNode,
+      repoId: repoId,
+    });
+    if (findEntryResult.entry) {
+      entryFound = findEntryResult.entry;
+      entryFound.fullPath = pathToNode; // overwrite the path. The pathToNode from the identifier is different from the returned path when the entry is a folder under a shortcut.
+    } else {
+      throw new Error(`Unable to get entry with path: ${pathToNode}`);
+    }
+    return entryFound;
+  }
+
+  private getLfEntryId(identifier: string): number | undefined {
+    if (identifier.startsWith('\\')) {
+      return undefined;
+    }
+    let entryId: number = parseInt(identifier, 10);
+    if (Number.isInteger(entryId)) {
+      return entryId;
+    } else {
+      return undefined;
+    }
   }
 
   private async createTreeNodeAsync(entryFound: Entry): Promise<LfTreeNode> {
@@ -301,35 +335,6 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
       treeNode = this.createRootFolderNode(repoName, entryFound);
     } else {
       treeNode = this.createNonRootLfRepoTreeNode(entryFound);
-    }
-    return treeNode;
-  }
-
-  /**
-   * Returns the LfRepoTreeNode represented by the path
-   * @param entryId Laserfiche Repository Entry Id for the node.
-   * @returns The LfRepoTreeNode with the specific Laserfiche Repository Entry Id, or rootTreeNode if access denied to the LfRepoTreeNode, or throws if it does not exist
-   * @example
-   * ``` ts
-   * // suppose the repository is structured as below
-   * - root 1
-   *      - DocInRoot with entry id 100
-   *      - FolderInRoot1 with entry id 101
-   *            - DocInFolderInRoot with entry id 1001
-   * const nonExistentNode = getTreeNodeByIdentifierAsync(333); // throws, will be caught by repository browser
-   * ```
-   */
-  async getTreeNodeByEntryIdAsync(entryId: number): Promise<LfTreeNode | undefined> {
-    const repoId = await this.repoClient.getCurrentRepoId();
-    const entryFound: Entry = await this.repoClient.entriesClient.getEntry({
-      entryId: entryId,
-      repoId: repoId,
-    });
-    let treeNode: LfTreeNode;
-    if (entryFound) {
-      treeNode = await this.createTreeNodeAsync(entryFound);
-    } else {
-      throw new Error(`Unable to get entry with EntryId: ${entryId}`);
     }
     return treeNode;
   }

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -279,8 +279,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
    */
   async getTreeNodeByIdentifierAsync(pathToNode: string): Promise<LfTreeNode | undefined> {
     const repoId: string = await this.repoClient.getCurrentRepoId();
-    var treeNode: LfTreeNode;
-    try {
+    let treeNode: LfTreeNode;
       const findEntryResult: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
         fullPath: pathToNode,
         repoId: repoId,
@@ -291,19 +290,10 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
       } else {
         throw new Error(`Unable to get entry with identifier: ${pathToNode}`);
       }
-    } catch (err: any) {
-      if (err.errorCode === 9013 || err.status === 403) {
-        treeNode = await this.getRootTreeNodeAsync();
-      } else {
-        throw err;
-      }
-    }
     return treeNode;
   }
 
-  private async createTreeNodeAsync(
-    entryFound: Entry,
-  ): Promise<LfTreeNode> {
+  private async createTreeNodeAsync(entryFound: Entry): Promise<LfTreeNode> {
     let treeNode: LfTreeNode;
     let isRoot: boolean = entryFound.id === 1;
     if (isRoot) {
@@ -326,30 +316,20 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
    *      - DocInRoot with entry id 100
    *      - FolderInRoot1 with entry id 101
    *            - DocInFolderInRoot with entry id 1001
-   *            - FolderInFolderInRoot with entry id 1002 (no access)
-   * const rootNode = getTreeNodeByEntryIdAsync(1002); // returns the definition for root
    * const nonExistentNode = getTreeNodeByIdentifierAsync(333); // throws, will be caught by repository browser
    * ```
    */
   async getTreeNodeByEntryIdAsync(entryId: number): Promise<LfTreeNode | undefined> {
     const repoId = await this.repoClient.getCurrentRepoId();
-    var treeNode: LfTreeNode;
-    try {
-      const entryFound: Entry = await this.repoClient.entriesClient.getEntry({
-        entryId: entryId,
-        repoId: repoId
-      });
-      if (entryFound) {
-        treeNode = await this.createTreeNodeAsync(entryFound);
-      } else {
-        throw new Error(`Unable to get entry with EntryId: ${entryId}`);
-      }
-    } catch (err: any) {
-      if (err.errorCode === 9013 || err.status === 403) {
-        treeNode = await this.getRootTreeNodeAsync();
-      } else {
-        throw err;
-      }
+    const entryFound: Entry = await this.repoClient.entriesClient.getEntry({
+      entryId: entryId,
+      repoId: repoId,
+    });
+    let treeNode: LfTreeNode;
+    if (entryFound) {
+      treeNode = await this.createTreeNodeAsync(entryFound);
+    } else {
+      throw new Error(`Unable to get entry with EntryId: ${entryId}`);
     }
     return treeNode;
   }

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -156,7 +156,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
         return await this.getRootTreeNodeAsync();
       }
     } catch (err: any) {
-      if (err.errorCode === 9013) {
+      if (err.errorCode === 9013 || err.status === 403) {
         const rootNode = await this.getRootTreeNodeAsync();
         return rootNode;
       } else {
@@ -257,7 +257,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
 
   /**
    * Returns the LfRepoTreeNode represented by the path
-   * @param identifier Unique identifier for the node, in this implementation the path of the node
+   * @param nodePath Unique identifier for the node, in this implementation the path of the node
    * @returns The LfRepoTreeNode at the specified path, or throws if it does not exist
    * @example
    * ``` ts
@@ -277,38 +277,81 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
    * const nestedUnderShortcut = getTreeNodeByIdentifierAsync('\FolderInRoot2\ShortcutToFolderInRoot1\DocInFolderInRoot') // returns definition for DocInFolderInRoot, with path to shortcut rather than path to true location
    * ```
    */
-  async getTreeNodeByIdentifierAsync(identifier: string): Promise<LfTreeNode | undefined> {
-    const repoName: string = await this.repoClient.getCurrentRepoName();
+  async getTreeNodeByIdentifierAsync(pathToNode: string): Promise<LfTreeNode | undefined> {
     const repoId: string = await this.repoClient.getCurrentRepoId();
-    const pathToNode: string = identifier;
+    var treeNode: LfTreeNode;
     try {
-      const entryFound: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
-        repoId,
+      const findEntryResult: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
         fullPath: pathToNode,
+        repoId: repoId,
       });
-
-      if (entryFound.entry) {
-        const entryWithSpecifiedPath: Entry = entryFound.entry;
-        entryWithSpecifiedPath.fullPath = pathToNode;
-        let treeNode: LfTreeNode;
-        if (entryWithSpecifiedPath.id === 1) {
-          treeNode = this.createRootFolderNode(repoName, entryWithSpecifiedPath);
-        } else {
-          treeNode = this.createNonRootLfRepoTreeNode(entryWithSpecifiedPath);
-        }
-
-        return treeNode;
+      if (findEntryResult.entry) {
+        treeNode = await this.createTreeNodeAsync(findEntryResult.entry);
+        treeNode.path = pathToNode; // overwrite the path. pathToNode is different from the returned path when the entry is a folder under a shortcut.
       } else {
-        throw new Error(`Unable to get entry with path: ${pathToNode}`);
+        throw new Error(`Unable to get entry with identifier: ${pathToNode}`);
       }
     } catch (err: any) {
       if (err.errorCode === 9013 || err.status === 403) {
-        const rootNode = await this.getRootTreeNodeAsync();
-        return rootNode;
+        treeNode = await this.getRootTreeNodeAsync();
       } else {
         throw err;
       }
     }
+    return treeNode;
+  }
+
+  private async createTreeNodeAsync(
+    entryFound: Entry,
+  ): Promise<LfTreeNode> {
+    let treeNode: LfTreeNode;
+    let isRoot: boolean = entryFound.id === 1;
+    if (isRoot) {
+      const repoName: string = await this.repoClient.getCurrentRepoName();
+      treeNode = this.createRootFolderNode(repoName, entryFound);
+    } else {
+      treeNode = this.createNonRootLfRepoTreeNode(entryFound);
+    }
+    return treeNode;
+  }
+
+  /**
+   * Returns the LfRepoTreeNode represented by the path
+   * @param entryId Laserfiche Repository Entry Id for the node.
+   * @returns The LfRepoTreeNode with the specific Laserfiche Repository Entry Id, or rootTreeNode if access denied to the LfRepoTreeNode, or throws if it does not exist
+   * @example
+   * ``` ts
+   * // suppose the repository is structured as below
+   * - root 1
+   *      - DocInRoot with entry id 100
+   *      - FolderInRoot1 with entry id 101
+   *            - DocInFolderInRoot with entry id 1001
+   *            - FolderInFolderInRoot with entry id 1002 (no access)
+   * const rootNode = getTreeNodeByEntryIdAsync(1002); // returns the definition for root
+   * const nonExistentNode = getTreeNodeByIdentifierAsync(333); // throws, will be caught by repository browser
+   * ```
+   */
+  async getTreeNodeByEntryIdAsync(entryId: number): Promise<LfTreeNode | undefined> {
+    const repoId = await this.repoClient.getCurrentRepoId();
+    var treeNode: LfTreeNode;
+    try {
+      const entryFound: Entry = await this.repoClient.entriesClient.getEntry({
+        entryId: entryId,
+        repoId: repoId
+      });
+      if (entryFound) {
+        treeNode = await this.createTreeNodeAsync(entryFound);
+      } else {
+        throw new Error(`Unable to get entry with EntryId: ${entryId}`);
+      }
+    } catch (err: any) {
+      if (err.errorCode === 9013 || err.status === 403) {
+        treeNode = await this.getRootTreeNodeAsync();
+      } else {
+        throw err;
+      }
+    }
+    return treeNode;
   }
 
   private createRootFolderNode(repoName: string, rootEntry: Entry) {

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -302,7 +302,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
         throw new Error(`Unable to get entry with path: ${pathToNode}`);
       }
     } catch (err: any) {
-      if (err.errorCode === 9013) {
+      if (err.errorCode === 9013 || err.status === 403) {
         const rootNode = await this.getRootTreeNodeAsync();
         return rootNode;
       } else {

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -30,12 +30,6 @@ export const nodeAttrName_elecDocumentSize = 'elecDocumentSize';
 export const nodeAttrName_templateName = 'templateName';
 export const nodeAttrName_creationTime = 'creationTime';
 const rootFolderId: number = 1;
-
-interface LfTreeNodeId {
-  entryId?: number;
-  pathToNode?: string;
-}
-
 export class LfRepoTreeNodeService implements LfTreeNodeService {
   /**
    * An array containing entryTypes (defined in '@laserfiche/lf-repository-api-client') for viewable entries

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -281,25 +281,33 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     const repoName: string = await this.repoClient.getCurrentRepoName();
     const repoId: string = await this.repoClient.getCurrentRepoId();
     const pathToNode: string = identifier;
+    try {
+      const entryFound: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
+        repoId,
+        fullPath: pathToNode,
+      });
 
-    const entryFound: FindEntryResult = await this.repoClient.entriesClient.getEntryByPath({
-      repoId,
-      fullPath: pathToNode,
-    });
+      if (entryFound.entry) {
+        const entryWithSpecifiedPath: Entry = entryFound.entry;
+        entryWithSpecifiedPath.fullPath = pathToNode;
+        let treeNode: LfTreeNode;
+        if (entryWithSpecifiedPath.id === 1) {
+          treeNode = this.createRootFolderNode(repoName, entryWithSpecifiedPath);
+        } else {
+          treeNode = this.createNonRootLfRepoTreeNode(entryWithSpecifiedPath);
+        }
 
-    if (entryFound.entry) {
-      const entryWithSpecifiedPath: Entry = entryFound.entry;
-      entryWithSpecifiedPath.fullPath = pathToNode;
-      let treeNode: LfTreeNode;
-      if (entryWithSpecifiedPath.id === 1) {
-        treeNode = this.createRootFolderNode(repoName, entryWithSpecifiedPath);
+        return treeNode;
       } else {
-        treeNode = this.createNonRootLfRepoTreeNode(entryWithSpecifiedPath);
+        throw new Error(`Unable to get entry with path: ${pathToNode}`);
       }
-
-      return treeNode;
-    } else {
-      throw new Error(`Unable to get entry with path: ${pathToNode}`);
+    } catch (err: any) {
+      if (err.errorCode === 9013) {
+        const rootNode = await this.getRootTreeNodeAsync();
+        return rootNode;
+      } else {
+        throw err;
+      }
     }
   }
 
@@ -334,7 +342,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     }
 
     const icon = this.getIconsForEntry(entry, parent);
-  
+
     switch (targetEntryType) {
       case EntryType.Folder:
       case EntryType.RecordSeries:


### PR DESCRIPTION
Fix:

- [Bug 617356](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/617356): lf-repository-browser: entering folder that has been renamed does not refresh folder name

- ⁠[Bug 617361](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/617361): lf-repository-browser.component: UI gets stuck if can't find folder.