### PR TITLE
Fetch all available templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:ci": "npm run test -- --watchAll=false --reporters=default --reporters=jest-junit",
     "lint": "eslint",
     "build": "tsc",
-    "generate-doc": "npx typedoc src/index.ts --out ./doc --excludePrivate"
+    "generate-doc": "npx typedoc@0.28.17 src/index.ts --out ./doc --excludePrivate"
   },
   "repository": {
     "type": "git",

--- a/src/service-implementations/lf-fields.service.ts
+++ b/src/service-implementations/lf-fields.service.ts
@@ -27,6 +27,7 @@ export class LfFieldsService implements LfFieldContainerService {
   private cachedTemplateFields: { id: number | string; fieldInfos: ApiTemplateFieldInfo[] } | undefined;
   private cachedTemplateDefinitions: TemplateInfo[] | undefined;
   private templateChanged: boolean = false;
+  private defaultPageSize: number = 100;
 
   constructor(private repoClient: IRepositoryApiClientEx, private lfDefaultFieldsService?: LfDefaultFieldsService) { }
 
@@ -79,16 +80,22 @@ export class LfFieldsService implements LfFieldContainerService {
 
   async getAvailableTemplatesAsync(): Promise<TemplateInfo[]> {
     if (!this.cachedTemplateDefinitions) {
-      const repositoryId = await this.repoClient.getCurrentRepoId();
-      const templateInfo: TemplateDefinitionCollectionResponse =
-        await this.repoClient.templateDefinitionsClient.listTemplateDefinitions({ repositoryId });
-      const templates = templateInfo.value as TemplateDefinition[];
-      templates.forEach((template) => {
-        if (!template.displayName) {
-          template.displayName = template.name;
+      let resultTemplateDefinitions: TemplateDefinition[] = [];
+      const callback = async (response: TemplateDefinitionCollectionResponse): Promise<boolean> => {
+        if (!response.value || response.value.length === 0) {
+          return false;
         }
-      });
-      this.cachedTemplateDefinitions = templateInfo.value as TemplateInfo[];
+
+        resultTemplateDefinitions = [...resultTemplateDefinitions, ...response.value]
+        return true;
+      };
+
+      const repositoryId = await this.repoClient.getCurrentRepoId();
+      await this.repoClient.templateDefinitionsClient.listTemplateDefinitionsForEach({ callback, repositoryId, maxPageSize: this.defaultPageSize});
+
+      // transform the result into TemplateInfo objects
+      const resultTemplateInfo = resultTemplateDefinitions.map((template) => ({...template, displayName: template.displayName ?? template.name} as TemplateInfo));
+      this.cachedTemplateDefinitions = resultTemplateInfo;
     }
     return this.cachedTemplateDefinitions;
   }

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -344,9 +344,9 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     let treeNode: LfRepoTreeNode | undefined;
     let entryName: string | undefined = entry.name;
     if (!entryName || entryName.length === 0) {
-      entryName = entry.id.toString();
+      entryName = entry.id?.toString() ?? '';
     }
-    let path: string = entry.fullPath;
+    let path: string | undefined = entry.fullPath;
     if (!path && parent) {
       path = this.getFullPath(parent, entryName);
     }
@@ -355,7 +355,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
       throw new Error(`Unable to determine path of entry: ${entry.id}`);
     }
 
-    const targetEntryType: EntryType = (entry as Shortcut).targetType
+    const targetEntryType: EntryType | undefined = (entry as Shortcut).targetType
       ? (entry as Shortcut).targetType
       : entry.entryType;
 
@@ -368,10 +368,10 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     switch (targetEntryType) {
       case EntryType.Folder:
       case EntryType.RecordSeries:
-        treeNode = this.createFolderNode(entryName, path, entry.id, entry.entryType, icon);
+        treeNode = this.createFolderNode(entryName, path, entry.id ?? 0, entry.entryType ?? EntryType.Folder, icon);
         break;
       case EntryType.Document:
-        treeNode = this.createLeafNode(entryName, path, entry.id, entry.entryType, icon);
+        treeNode = this.createLeafNode(entryName, path, entry.id ?? 0, entry.entryType ?? EntryType.Document, icon);
         break;
       default:
         throw new Error(`Unsupported entry type for entry: ${entry.id}`);
@@ -382,7 +382,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     return treeNode;
   }
 
-  private getSingleIconForEntryType(entryType: EntryType, parent?: LfRepoTreeNode, extension?: string): string {
+  private getSingleIconForEntryType(entryType?: EntryType, parent?: LfRepoTreeNode, extension?: string): string {
     switch (entryType) {
       case EntryType.Folder: {
         const isParentShortcutRecordSeries =
@@ -415,21 +415,24 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
   }
 
   private isViewable(entry: Entry): boolean {
-    return (
-      (this.viewableEntryTypes?.includes(entry.entryType) && entry.entryType !== EntryType.Shortcut) ||
+    const entryType = entry.entryType;
+    const targetEntryType = (entry as Shortcut).targetType;
+
+    return !!(
+      (entryType && this.viewableEntryTypes?.includes(entryType) && entryType !== EntryType.Shortcut) ||
       (this.viewableEntryTypes?.includes(EntryType.Shortcut) &&
-        entry.entryType === EntryType.Shortcut &&
-        this.viewableEntryTypes?.includes((entry as Shortcut).targetType))
+        entryType === EntryType.Shortcut &&
+        targetEntryType && this.viewableEntryTypes?.includes(targetEntryType))
     );
   }
 
   private valueToPropertyValue(value: string | Date | number | undefined, columnId: string | undefined): PropertyValue {
-    let displayValue: string = value ? value.toString() : undefined;
+    let displayValue: string | undefined = value ? value.toString() : undefined;
 
     switch (columnId) {
       case nodeAttrName_creationTime:
       case nodeAttrName_lastModifiedTime: {
-        const date = new Date(value);
+        const date = value ? new Date(value) : new Date();
         displayValue = new Intl.DateTimeFormat('en-US', {
           year: 'numeric',
           month: 'numeric',
@@ -453,9 +456,9 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
   }
 
   private setColumnAttributesForEntry(entry: Document | Folder | Shortcut | RecordSeries, node: LfRepoTreeNode) {
-    if (this.columnIds) {
+    if (this.columnIds && node.attributes) {
       for (const columnId of this.columnIds) {
-        node.attributes.set(columnId, this.valueToPropertyValue(entry[columnId], columnId));
+        node.attributes.set(columnId, this.valueToPropertyValue((entry as any)[columnId], columnId));
       }
     }
   }
@@ -540,8 +543,8 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     }
     const repositoryId: string = await this.repoClient.getCurrentRepoId();
     if (orderBy && !allSupportedRepositoryColumnIds.includes(orderBy.columnId)) {
-      orderBy = undefined;
       console.error(`Cannot order by unsupported column: ${orderBy.columnId}`);
+      orderBy = undefined;
     }
 
     const requestParameters = getFolderChildrenDefaultParameters(repositoryId, entryId, this.columnIds, orderBy);

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -368,10 +368,10 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     switch (targetEntryType) {
       case EntryType.Folder:
       case EntryType.RecordSeries:
-        treeNode = this.createFolderNode(entryName, path, entry.id ?? 0, entry.entryType ?? EntryType.Folder, icon);
+        treeNode = this.createFolderNode(entryName, path, entry.id ?? rootFolderId, entry.entryType ?? EntryType.Folder, icon);
         break;
       case EntryType.Document:
-        treeNode = this.createLeafNode(entryName, path, entry.id ?? 0, entry.entryType ?? EntryType.Document, icon);
+        treeNode = this.createLeafNode(entryName, path, entry.id ?? rootFolderId, entry.entryType ?? EntryType.Document, icon);
         break;
       default:
         throw new Error(`Unsupported entry type for entry: ${entry.id}`);

--- a/src/service-implementations/lf-repo-tree-node-service.ts
+++ b/src/service-implementations/lf-repo-tree-node-service.ts
@@ -341,10 +341,14 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
   }
 
   private createNonRootLfRepoTreeNode(entry: Entry, parent?: LfRepoTreeNode): LfRepoTreeNode {
+    if (!entry.id) {
+      throw new Error('Entry id is undefined');
+    }
+
     let treeNode: LfRepoTreeNode | undefined;
     let entryName: string | undefined = entry.name;
     if (!entryName || entryName.length === 0) {
-      entryName = entry.id?.toString() ?? '';
+      entryName = entry.id.toString();
     }
     let path: string | undefined = entry.fullPath;
     if (!path && parent) {
@@ -359,7 +363,7 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
       ? (entry as Shortcut).targetType
       : entry.entryType;
 
-    if (!targetEntryType) {
+    if (!targetEntryType || !entry.entryType) {
       throw new Error(`Entry type is undefined for entry: ${entry.id}`);
     }
 
@@ -368,10 +372,10 @@ export class LfRepoTreeNodeService implements LfTreeNodeService {
     switch (targetEntryType) {
       case EntryType.Folder:
       case EntryType.RecordSeries:
-        treeNode = this.createFolderNode(entryName, path, entry.id ?? rootFolderId, entry.entryType ?? EntryType.Folder, icon);
+        treeNode = this.createFolderNode(entryName, path, entry.id, entry.entryType, icon);
         break;
       case EntryType.Document:
-        treeNode = this.createLeafNode(entryName, path, entry.id ?? rootFolderId, entry.entryType ?? EntryType.Document, icon);
+        treeNode = this.createLeafNode(entryName, path, entry.id, entry.entryType, icon);
         break;
       default:
         throw new Error(`Unsupported entry type for entry: ${entry.id}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,10 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es2015",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    "target": "es2017",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
     "module": "es2015",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": [
-      "ES2015",
+      "ES2017",
       "dom"
     ],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true,                             /* Allow javascript files to be compiled. */
@@ -47,7 +47,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
     "stripInternal": true,
     /* Module Resolution Options */
-    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es2017",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    "target": "es2015",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
     "module": "es2015",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": [
       "ES2017",
@@ -47,7 +47,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
     "stripInternal": true,
     /* Module Resolution Options */
-    "moduleResolution": "bundler",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
This PR enhanced the `getAvailableTemplatesAsync` function that paginates through templates until all items are fetched. Previously, only the first page of templates was returned.