### PR TITLE
operator precedence bug in dynamic field error handling; update Veracode action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  NPM_VERSION: "21.1.0"
+  NPM_VERSION: "21.1.1"
 
 permissions:
   contents: write

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -37,11 +37,12 @@ jobs:
         run: tar -czvf ./veracode/ui-components-services.tar.gz ./src
 
       - name: Veracode Upload And Scan (Static Application Security Testing)
-        uses: veracode/veracode-uploadandscan-action@0.2.11
+        uses: veracode/uploadandscan-action@v0.2.2
         with:
           appname: "lf-ui-components-services"
           createprofile: true
           filepath: "veracode"
+          version: "${{ github.run_id }}"
           vid: "${{ secrets.VERACODE_API_ID }}"
           vkey: "${{ secrets.VERACODE_API_KEY }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
+## 21.1.1
+
+### Fixes
+
+- `LfFieldsService`: silently return empty options when `getDynamicFieldValueOptionsAsync` encounters an HTTP 500 with error code `[9597]` (`LFCR_E_FORM_LOGIC_RULES_ENGINE_ERROR`); all other errors are re-thrown.
 
 ## 21.1.0
 

--- a/src/service-implementations/lf-fields.service.ts
+++ b/src/service-implementations/lf-fields.service.ts
@@ -166,7 +166,7 @@ export class LfFieldsService implements LfFieldContainerService {
         request: dynamicRequest,
       });
     } catch (error: any) {
-      if (error.status === '500' && error.message?.includes('9597')) {
+      if (error.status === '500' && (error.message?.includes('9597') ?? false)) {
         // 9597: LFCR_E_FORM_LOGIC_RULES_ENGINE_ERROR
         console.error('getDynamicFieldValueOptionsAsync: returning empty dynamic field options', error);
         return optionsById;

--- a/src/service-implementations/lf-fields.service.ts
+++ b/src/service-implementations/lf-fields.service.ts
@@ -166,7 +166,7 @@ export class LfFieldsService implements LfFieldContainerService {
         request: dynamicRequest,
       });
     } catch (error: any) {
-      if (error.status === '500' && (error.message?.includes('9597') ?? false)) {
+      if (error.status === 500 && (error.message?.includes('9597') ?? false)) {
         // 9597: LFCR_E_FORM_LOGIC_RULES_ENGINE_ERROR
         console.error('getDynamicFieldValueOptionsAsync: returning empty dynamic field options', error);
         return optionsById;


### PR DESCRIPTION
[Bug 674900](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/674900): Outlook Add-in should treat dynamic field evaluation failures as an empty list instead of bombing out
## fix: catch 9597 engine error in getDynamicFieldValueOptionsAsync; update Veracode action

**Bug fixes**
- Fix `error.status` compared as string `'500'` instead of number `500`; `ApiException.status`
  is typed as `number`, so the check always failed and the 9597 form-logic engine error was
  never caught, causing it to throw instead of returning empty field options
- Add `?? false` to the optional chaining expression to prevent a TypeScript compiler
  operator-precedence issue when targeting ES2015

**CI**
- Upgrade Veracode upload action from `veracode/veracode-uploadandscan-action@0.2.11`
  to `veracode/uploadandscan-action@v0.2.2`
- Add required `version` input (set to `github.run_id`) for the new action version
