### PR TITLE
Fix: return undefined for auto-select template when resolution fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  NPM_VERSION: "21.1.1"
+  NPM_VERSION: "21.1.2"
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
+## 21.1.2
+
+### Fixes
+
+- `LfFieldsService`: `getTemplateDefinitionAsync` returns `undefined` for `<Automatically select template>` when it fails to resolve the template.
+
 ## 21.1.1
 
 ### Fixes

--- a/src/service-implementations/lf-fields.service.spec.ts
+++ b/src/service-implementations/lf-fields.service.spec.ts
@@ -162,7 +162,7 @@ describe('LfFieldsService', () => {
     const autoSelectTemplateId = 2147483646;
     mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
       .fn()
-      .mockRejectedValue(new Error('some unknown error'));
+      .mockRejectedValue({ status: 500, message: 'Internal server error' });
 
     // Act
     const result = await service.getTemplateDefinitionAsync(autoSelectTemplateId);
@@ -183,20 +183,6 @@ describe('LfFieldsService', () => {
       status: 403,
       message: 'Access denied. [9013]',
     });
-  });
-
-  it('get template definition: when the auto-select template id fails with an unrelated error, then it still returns undefined instead of throwing', async () => {
-    // Arrange
-    const autoSelectTemplateId = 2147483646;
-    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
-      .fn()
-      .mockRejectedValue({ status: 500, message: 'Internal server error' });
-
-    // Act
-    const result = await service.getTemplateDefinitionAsync(autoSelectTemplateId);
-
-    // Assert
-    expect(result).toBeUndefined();
   });
 
   it('caches template fields', async () => {

--- a/src/service-implementations/lf-fields.service.spec.ts
+++ b/src/service-implementations/lf-fields.service.spec.ts
@@ -131,6 +131,32 @@ describe('LfFieldsService', () => {
     });
   });
 
+  it('get template definition: when no template definition is found for the id, then it returns undefined instead of throwing', async () => {
+    // Arrange
+    const templateId = 2147483646;
+    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest.fn().mockResolvedValue(undefined);
+
+    // Act
+    const result = await service.getTemplateDefinitionAsync(templateId);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it('get template definition: when a template definition is found without a display name, then it falls back to the name', async () => {
+    // Arrange
+    const templateId = 123;
+    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
+      .fn()
+      .mockResolvedValue({ id: templateId, name: 'MyTemplate' });
+
+    // Act
+    const result = await service.getTemplateDefinitionAsync(templateId);
+
+    // Assert
+    expect(result).toEqual({ id: templateId, name: 'MyTemplate', displayName: 'MyTemplate' });
+  });
+
   it('caches template fields', async () => {
     // Arrange
     const templateId = 123;

--- a/src/service-implementations/lf-fields.service.spec.ts
+++ b/src/service-implementations/lf-fields.service.spec.ts
@@ -157,6 +157,48 @@ describe('LfFieldsService', () => {
     expect(result).toEqual({ id: templateId, name: 'MyTemplate', displayName: 'MyTemplate' });
   });
 
+  it('get template definition: when the server returns 403/9013 for the auto-select template id, then it returns undefined instead of throwing', async () => {
+    // Arrange
+    const autoSelectTemplateId = 2147483646;
+    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
+      .fn()
+      .mockRejectedValue({ status: 403, message: 'Access denied. [9013]' });
+
+    // Act
+    const result = await service.getTemplateDefinitionAsync(autoSelectTemplateId);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it('get template definition: when a non-auto-select template id fails, then it still throws', async () => {
+    // Arrange
+    const templateId = 123;
+    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
+      .fn()
+      .mockRejectedValue({ status: 403, message: 'Access denied. [9013]' });
+
+    // Act & Assert
+    await expect(service.getTemplateDefinitionAsync(templateId)).rejects.toEqual({
+      status: 403,
+      message: 'Access denied. [9013]',
+    });
+  });
+
+  it('get template definition: when the auto-select template id fails with an unrelated error, then it still returns undefined instead of throwing', async () => {
+    // Arrange
+    const autoSelectTemplateId = 2147483646;
+    mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
+      .fn()
+      .mockRejectedValue({ status: 500, message: 'Internal server error' });
+
+    // Act
+    const result = await service.getTemplateDefinitionAsync(autoSelectTemplateId);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
   it('caches template fields', async () => {
     // Arrange
     const templateId = 123;

--- a/src/service-implementations/lf-fields.service.spec.ts
+++ b/src/service-implementations/lf-fields.service.spec.ts
@@ -157,12 +157,12 @@ describe('LfFieldsService', () => {
     expect(result).toEqual({ id: templateId, name: 'MyTemplate', displayName: 'MyTemplate' });
   });
 
-  it('get template definition: when the server returns 403/9013 for the auto-select template id, then it returns undefined instead of throwing', async () => {
+  it('get template definition: when the server fails to resolve the auto-select template id, then it returns undefined instead of throwing', async () => {
     // Arrange
     const autoSelectTemplateId = 2147483646;
     mockRepoClient.templateDefinitionsClient.getTemplateDefinition = jest
       .fn()
-      .mockRejectedValue({ status: 403, message: 'Access denied. [9013]' });
+      .mockRejectedValue(new Error('some unknown error'));
 
     // Act
     const result = await service.getTemplateDefinitionAsync(autoSelectTemplateId);

--- a/src/service-implementations/lf-fields.service.ts
+++ b/src/service-implementations/lf-fields.service.ts
@@ -22,6 +22,8 @@ import {
   TemplateFieldDefinition as ApiTemplateFieldInfo,
 } from '@laserfiche/lf-repository-api-client-v2';
 
+const WELL_KNOWN_AUTOMATICALLY_SELECTED_TEMPLATE_ID = 2147483646;
+
 export class LfFieldsService implements LfFieldContainerService {
   private cachedFieldDefinitions: FieldDefinition[] | undefined;
   private cachedTemplateFields: { id: number | string; fieldInfos: ApiTemplateFieldInfo[] } | undefined;
@@ -51,10 +53,16 @@ export class LfFieldsService implements LfFieldContainerService {
         });
       templateDefinition = templateDefinitions.value?.[0];
     } else {
-      templateDefinition = await this.repoClient?.templateDefinitionsClient.getTemplateDefinition({
-        repositoryId,
-        templateId: templateIdentifier,
-      });
+      try {
+        templateDefinition = await this.repoClient?.templateDefinitionsClient.getTemplateDefinition({
+          repositoryId,
+          templateId: templateIdentifier,
+        });
+      } catch (error: any) {
+        if (templateIdentifier !== WELL_KNOWN_AUTOMATICALLY_SELECTED_TEMPLATE_ID) {
+          throw error;
+        }
+      }
     }
     if (templateDefinition && !templateDefinition.displayName) {
       templateDefinition.displayName = templateDefinition.name;

--- a/src/service-implementations/lf-fields.service.ts
+++ b/src/service-implementations/lf-fields.service.ts
@@ -56,8 +56,8 @@ export class LfFieldsService implements LfFieldContainerService {
         templateId: templateIdentifier,
       });
     }
-    if (!templateDefinition?.displayName) {
-      templateDefinition!.displayName = templateDefinition?.name;
+    if (templateDefinition && !templateDefinition.displayName) {
+      templateDefinition.displayName = templateDefinition.name;
     }
     return templateDefinition as TemplateInfo;
   }


### PR DESCRIPTION
[Bug 685770](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/685770): [Office Add-in] Loading Error in Template when switching between repositories and no template assigned

- **Fixes**
  - `LfFieldsService.getTemplateDefinitionAsync`: catch failures when resolving the well-known "Automatically select template" ID (`2147483646`) and return `undefined` instead of throwing.
  - Guard the `displayName` fallback so it no longer throws when `templateDefinition` is `undefined`.
- **Tests**
  - Add spec coverage for the auto-select template failure path and the `displayName` fallback guard.
- **Chore**
  - Bump changelog to `21.1.2` documenting the fix.
